### PR TITLE
Remove isCustom from models

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-models",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Hypersync Models",
   "repository": {
     "type": "git",

--- a/src/criteria.ts
+++ b/src/criteria.ts
@@ -50,7 +50,6 @@ export interface ICriteriaFieldConfig {
   valueProperty?: string;
   labelProperty?: string;
   fixedValues?: ISelectOption[];
-  isCustom?: boolean;
 }
 
 /**

--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -38,7 +38,6 @@ export interface IDataSet {
   transform?: Transform;
   sort?: SortClause[];
   result: 'array' | 'object';
-  isCustom?: boolean;
 }
 
 /**

--- a/src/proofTypes.ts
+++ b/src/proofTypes.ts
@@ -39,7 +39,6 @@ export interface IProofType {
   label: string;
   category?: string;
   isJson: boolean;
-  isCustom: boolean;
 }
 
 /**


### PR DESCRIPTION
When we started the designer work I added the `isCustom` property to some of our models to help us distinguish built-in objects from objects that were created by our users in the designer.

Since that time our thinking has evolved.  We have decided to prefix all of our built-in objects with `hp_` and that prefix can be used to determine if something is or is not custom.

This change removes the `isCustom` property since it is no longer necesssary.