### PR TITLE
Convert data source messages to value lookups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-models",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Hypersync Models",
   "repository": {
     "type": "git",

--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -41,6 +41,11 @@ export interface IDataSet {
 }
 
 /**
+ * Maps a value to a message that can be rendered in a generated proof.
+ */
+export type ValueLookup = { [value: string]: string };
+
+/**
  * Configuration information stored in a JSON file that is used as
  * the input to a RestDataSourceBase instance.
  */
@@ -49,7 +54,14 @@ export interface IRestDataSourceConfig {
   dataSets: {
     [name: string]: IDataSet;
   };
+  valueLookups?: {
+    [name: string]: ValueLookup;
+  };
+
+  /**
+   * @deprecated This property has been deprecated in favor of `valueLookups`
+   */
   messages?: {
-    [name: string]: { [key: string]: string };
+    [name: string]: ValueLookup;
   };
 }


### PR DESCRIPTION
As per our discussion on message lookups, this change adds a `valueLookups` member to the data source configuration and deprecates the `messages`  property.