### PR TITLE
Bump version to work around failed publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-models",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Hypersync Models",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I fumbled the publishing of 4.1.0.  Unfortunately npm doesn't allow you to re-publish something that has already been published.

Need to bump the version number here so that I can publish a functional package.