### PR TITLE
Fix IProofSpecOverride interface.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-models",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Hypersync Models",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-models",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Hypersync Models",
   "repository": {
     "type": "git",

--- a/src/proofTypes.ts
+++ b/src/proofTypes.ts
@@ -88,12 +88,28 @@ export interface IProofSpec {
   webPageUrl: string;
 }
 
+export interface IOverrideSpec {
+  period?: HypersyncPeriod;
+  useVersioning?: boolean;
+  suggestedName?: string;
+  format?: HypersyncDataFormat;
+  orientation?: HypersyncPageOrientation;
+  title?: string;
+  subtitle?: string;
+  dataSet?: string;
+  dataSetParams?: DataValueMap;
+  noResultsMessage?: string;
+  lookups?: IProofSpecLookup[];
+  fields?: IHypersyncField[];
+  webPageUrl?: string;
+}
+
 export interface IProofSpecOverride {
   condition: {
     value: string;
     criteria: string;
   };
-  proofSpec: IProofSpec;
+  proofSpec: IOverrideSpec;
 }
 
 export interface IHypersyncDefinition {

--- a/src/proofTypes.ts
+++ b/src/proofTypes.ts
@@ -88,28 +88,12 @@ export interface IProofSpec {
   webPageUrl: string;
 }
 
-export interface IOverrideSpec {
-  period?: HypersyncPeriod;
-  useVersioning?: boolean;
-  suggestedName?: string;
-  format?: HypersyncDataFormat;
-  orientation?: HypersyncPageOrientation;
-  title?: string;
-  subtitle?: string;
-  dataSet?: string;
-  dataSetParams?: DataValueMap;
-  noResultsMessage?: string;
-  lookups?: IProofSpecLookup[];
-  fields?: IHypersyncField[];
-  webPageUrl?: string;
-}
-
 export interface IProofSpecOverride {
   condition: {
     value: string;
     criteria: string;
   };
-  proofSpec: IOverrideSpec;
+  proofSpec: Partial<IProofSpec>;
 }
 
 export interface IHypersyncDefinition {


### PR DESCRIPTION
The `IProofSpecOverride` interface was incorrectly implemented.  The values in the `proofSpec` object property should all optional.