### PR TITLE
Make webPageUrl optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-models",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Hypersync Models",
   "repository": {
     "type": "git",

--- a/src/proofTypes.ts
+++ b/src/proofTypes.ts
@@ -85,7 +85,7 @@ export interface IProofSpec {
   noResultsMessage?: string;
   lookups?: IProofSpecLookup[];
   fields: IHypersyncField[];
-  webPageUrl: string;
+  webPageUrl?: string;
 }
 
 export interface IProofSpecOverride {


### PR DESCRIPTION
This change is required for the hypersync-sdk update that is in progress.