### PR TITLE
Update hypersync-models to 6.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/hypersync-models",
-  "version": "6.0.0-beta",
+  "version": "6.0.0-beta.1",
   "description": "Hypersync Models",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
I bungled the release process, so the version on npm didn't have all the right updates. New published version needs a new number.